### PR TITLE
Change decodeDatetime2 default to zero

### DIFF
--- a/replication/row_event.go
+++ b/replication/row_event.go
@@ -1428,7 +1428,7 @@ func decodeDatetime2(data []byte, dec uint16) (interface{}, int, error) {
 	}
 
 	if intPart == 0 {
-		return formatZeroTime(int(frac), int(dec)), n, nil
+		return nil, n, nil
 	}
 
 	tmp := intPart<<24 + frac


### PR DESCRIPTION
Change decodeDatetime2 to return nil instead of 0000-00-00 00:00:00 to match our other parsing types (MYSQL_TYPE_DATETIME,MYSQL_TYPE_TIMESTAMP2)
Testing will be added to the CDC Connector