### PR TITLE
Fix/eitam/safe data handling

### DIFF
--- a/replication/row_event.go
+++ b/replication/row_event.go
@@ -1336,10 +1336,23 @@ func decodeString(data []byte, length int) (v string, n int) {
 
 // Replaces smart quotes with ASCII equivalents
 func normalizeSmartQuotes(content []byte) []byte {
-	content = bytes.ReplaceAll(content, []byte("‘"), []byte("'"))
-	content = bytes.ReplaceAll(content, []byte("’"), []byte("'"))
-	content = bytes.ReplaceAll(content, []byte("“"), []byte("\""))
-	content = bytes.ReplaceAll(content, []byte("”"), []byte("\""))
+	content = bytes.ReplaceAll(content, []byte{0xE2, 0x80, 0x99}, []byte("'"))  // '
+	content = bytes.ReplaceAll(content, []byte{0xE2, 0x80, 0x9C}, []byte("\"")) // "
+	content = bytes.ReplaceAll(content, []byte{0xE2, 0x80, 0x9D}, []byte("\"")) // "
+
+	content = bytes.ReplaceAll(content, []byte{0x91}, []byte("'"))  // '
+	content = bytes.ReplaceAll(content, []byte{0x92}, []byte("'"))  // '
+	content = bytes.ReplaceAll(content, []byte{0x93}, []byte("\"")) // "
+	content = bytes.ReplaceAll(content, []byte{0x94}, []byte("\"")) // "
+
+	content = bytes.ReplaceAll(content, []byte{0x85}, []byte("...")) // …
+	content = bytes.ReplaceAll(content, []byte{0x96}, []byte("-"))   // –
+	content = bytes.ReplaceAll(content, []byte{0x97}, []byte("--"))  // —
+
+	content = bytes.ReplaceAll(content, []byte("â€™"), []byte("'"))     // Corrupted '
+	content = bytes.ReplaceAll(content, []byte("â€œ"), []byte("\""))    // Corrupted "
+	content = bytes.ReplaceAll(content, []byte("â€\x9d"), []byte("\"")) // Corrupted "
+
 	return content
 }
 

--- a/replication/row_event.go
+++ b/replication/row_event.go
@@ -1203,6 +1203,9 @@ func convertToString(s interface{}) (string, bool) {
 }
 
 func decodeStringByCharSet(data []byte, charset string, length int) (v string, n int) {
+	if len(data) == 0 {
+		return "", 0
+	}
 	enc, err := getDecoderByCharsetName(charset)
 	if err != nil {
 		log.Errorf(err.Error())

--- a/replication/row_event.go
+++ b/replication/row_event.go
@@ -1336,23 +1336,10 @@ func decodeString(data []byte, length int) (v string, n int) {
 
 // Replaces smart quotes with ASCII equivalents
 func normalizeSmartQuotes(content []byte) []byte {
-	content = bytes.ReplaceAll(content, []byte{0xE2, 0x80, 0x99}, []byte("'"))  // '
-	content = bytes.ReplaceAll(content, []byte{0xE2, 0x80, 0x9C}, []byte("\"")) // "
-	content = bytes.ReplaceAll(content, []byte{0xE2, 0x80, 0x9D}, []byte("\"")) // "
-
-	content = bytes.ReplaceAll(content, []byte{0x91}, []byte("'"))  // '
-	content = bytes.ReplaceAll(content, []byte{0x92}, []byte("'"))  // '
-	content = bytes.ReplaceAll(content, []byte{0x93}, []byte("\"")) // "
-	content = bytes.ReplaceAll(content, []byte{0x94}, []byte("\"")) // "
-
-	content = bytes.ReplaceAll(content, []byte{0x85}, []byte("...")) // …
-	content = bytes.ReplaceAll(content, []byte{0x96}, []byte("-"))   // –
-	content = bytes.ReplaceAll(content, []byte{0x97}, []byte("--"))  // —
-
-	content = bytes.ReplaceAll(content, []byte("â€™"), []byte("'"))     // Corrupted '
-	content = bytes.ReplaceAll(content, []byte("â€œ"), []byte("\""))    // Corrupted "
-	content = bytes.ReplaceAll(content, []byte("â€\x9d"), []byte("\"")) // Corrupted "
-
+	content = bytes.ReplaceAll(content, []byte("‘"), []byte("'"))
+	content = bytes.ReplaceAll(content, []byte("’"), []byte("'"))
+	content = bytes.ReplaceAll(content, []byte("“"), []byte("\""))
+	content = bytes.ReplaceAll(content, []byte("”"), []byte("\""))
 	return content
 }
 

--- a/replication/row_event.go
+++ b/replication/row_event.go
@@ -1203,9 +1203,6 @@ func convertToString(s interface{}) (string, bool) {
 }
 
 func decodeStringByCharSet(data []byte, charset string, length int) (v string, n int) {
-	if len(data) == 0 {
-		return "", 0
-	}
 	enc, err := getDecoderByCharsetName(charset)
 	if err != nil {
 		log.Errorf(err.Error())
@@ -1409,23 +1406,23 @@ func replaceUnsupportedCharacters(data []byte, length int) []byte {
 }
 
 func decodeStringWithEncoder(data []byte, length int, enc encoding.Encoding) (v string, n int) {
-	// Define the Latin1 decoder
 	decoder := enc.NewDecoder()
-	if !supportsSmartQuotes(enc) {
-		data = replaceUnsupportedCharacters(data, length)
-	}
 
 	if length < 256 {
-		// If the length is smaller than 256, extract the length from the first byte
 		length = int(data[0])
 		n = length + 1
 		decodedBytes, _, _ := transform.Bytes(decoder, data[1:n])
+		if !supportsSmartQuotes(enc) {
+			decodedBytes = normalizeSmartQuotes(decodedBytes)
+		}
 		v = string(decodedBytes)
 	} else {
-		// If the length is larger, extract it using LittleEndian
 		length = int(binary.LittleEndian.Uint16(data[0:]))
 		n = length + 2
 		decodedBytes, _, _ := transform.Bytes(decoder, data[2:n])
+		if !supportsSmartQuotes(enc) {
+			decodedBytes = normalizeSmartQuotes(decodedBytes)
+		}
 		v = string(decodedBytes)
 	}
 

--- a/replication/row_event.go
+++ b/replication/row_event.go
@@ -1363,48 +1363,6 @@ func supportsSmartQuotes(enc encoding.Encoding) bool {
 	return false
 }
 
-func replaceUnsupportedCharacters(data []byte, length int) []byte {
-	if len(data) == 0 {
-		return data
-	}
-
-	var content []byte
-	var prefix []byte
-	var contentLength int
-	var prefixLen int
-
-	if length > 255 {
-		// 2-byte length prefix (LittleEndian)
-		prefixLen = 2
-		contentLength = int(binary.LittleEndian.Uint16(data[:2]))
-		if contentLength > len(data)-prefixLen {
-			contentLength = len(data) - prefixLen
-		}
-		content = data[prefixLen : prefixLen+contentLength]
-	} else {
-		// 1-byte length prefix
-		prefixLen = 1
-		contentLength = int(data[0])
-		if contentLength > len(data)-prefixLen {
-			contentLength = len(data) - prefixLen
-		}
-		content = data[prefixLen : prefixLen+contentLength]
-	}
-
-	// Replace unsupported characters
-	content = normalizeSmartQuotes(content)
-
-	// Rebuild prefix with new length
-	if prefixLen == 2 {
-		prefix = make([]byte, 2)
-		binary.LittleEndian.PutUint16(prefix, uint16(len(content)))
-	} else {
-		prefix = []byte{byte(len(content))}
-	}
-
-	return append(prefix, content...)
-}
-
 func decodeStringWithEncoder(data []byte, length int, enc encoding.Encoding) (v string, n int) {
 	decoder := enc.NewDecoder()
 


### PR DESCRIPTION
## Fix MySQL Binlog Parser Stream Corruption

### Problem
The MySQL binlog parser was crashing with "index out of range" errors when processing international text containing smart quotes, causing data loss from batch failures.

### Root Cause
The `replaceUnsupportedCharacters` function was modifying data length during binary parsing, breaking stream synchronization:

```
Original MySQL binary stream:
[10]['Hello'world'][4][next_field]...
 ↑                    ↑
 "read 10 bytes"     next field at position 11

After replaceUnsupportedCharacters:
[8]['Hello'world'][xt_field]...
 ↑                  ↑
 "read 8 bytes"    corrupted read at position 9 (should be 11)

Smart quote ' (3 bytes UTF-8) → ' (1 byte ASCII)
Result: Stream offset wrong by 2 bytes, all subsequent reads fail
```

### Fix
Moved character normalization from binary parsing to post-decoding:

**Before (WRONG):**
```
Binary data → Replace quotes → Decode → String output
         ↑ Changes byte count!
```

**After (CORRECT):**
```
Binary data → Decode → String output → Replace quotes
         ↑ Preserves exact bytes
```

### Changes Made

1. **Updated `decodeStringWithEncoder`** - Apply `replaceUnsupportedCharacters` after decoding, not on raw bytes
2. **Fixed charset detection query** - Added VARCHAR/TEXT types that inherit charset from table collation

### Result
- Processed millions of messages without crashes
- Binary stream stays synchronized
- Smart quotes handled correctly for all charsets

### Key Lesson
Binary protocols require exact byte positioning. Never modify data length during parsing - handle character transformations after extraction.