### PR TITLE
feat: allow spaces in table/database names [DCI-752]

### DIFF
--- a/canal/canal.go
+++ b/canal/canal.go
@@ -436,7 +436,7 @@ func (c *Canal) checkBinlogRowFormat() error {
 
 func isSafeIdentifier(s string) bool {
 	for _, r := range s {
-		if !(unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '-') {
+		if !(unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' || r == '-' || r == ' ') {
 			return false
 		}
 	}

--- a/canal/canal_test.go
+++ b/canal/canal_test.go
@@ -508,8 +508,10 @@ func TestIsSafeIdentifier(t *testing.T) {
 		{"unicode letters", "tàble", true},
 		{"chinese characters", "表格", true},
 
+		// Space is valid (MySQL allows spaces in identifiers when quoted)
+		{"space", "my table", true},
+
 		// Invalid identifiers
-		{"space", "my table", false},
 		{"dot", "my.table", false},
 		{"at symbol", "@table", false},
 		{"hash symbol", "#table", false},


### PR DESCRIPTION
MySQL allows spaces in identifiers when quoted with backticks. The isSafeIdentifier validation was rejecting valid table names containing spaces.